### PR TITLE
Mise à jour du DSFR en 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Tous les changements notables de Ara sont documentés ici avec leur date, leur catégorie (nouvelle fonctionnalité, correction de bug ou autre changement) et leur pull request (PR) associée.
 
+## 23/03/2023
+
+## Autres changements ⚙️
+
+- Mise à jour du DSFR en version `1.9.0` ([#326](https://github.com/DISIC/Ara/pull/326))
+
 ## 08/03/2023
 
 ## Nouvelles fonctionnalités 🚀

--- a/confiture-web-app/.eslintrc
+++ b/confiture-web-app/.eslintrc
@@ -12,7 +12,8 @@
     "sourceType": "module"
   },
   "rules": {
-    "vue/multi-word-component-names": "off"
+    "vue/multi-word-component-names": "off",
+    "vue/no-v-html": "off"
   },
   "env": {
     "jest": true

--- a/confiture-web-app/package.json
+++ b/confiture-web-app/package.json
@@ -12,7 +12,7 @@
     "generate:rgaa": "node scripts/build-rgaa-files.js"
   },
   "dependencies": {
-    "@gouvfr/dsfr": "1.7.2",
+    "@gouvfr/dsfr": "1.9.0",
     "@sentry/tracing": "^7.37.2",
     "@sentry/vue": "^7.37.2",
     "@vueuse/head": "^1.0.22",

--- a/confiture-web-app/src/components/ReportErrors.vue
+++ b/confiture-web-app/src/components/ReportErrors.vue
@@ -377,23 +377,20 @@ function updateActiveAnchorLink(id: string, event: MouseEvent) {
           >
             {{ page.pageName }}
           </h2>
-          <!-- FIXME: remove this <div> with DSFR >= 1.8 -->
-          <div class="fr-mb-4w">
-            <a
-              :href="page.pageUrl"
-              class="page-url"
-              target="_blank"
-              rel="noopener"
-            >
-              {{ page.pageUrl }}
-              <span class="sr-only">(nouvelle fenêtre)</span>
-            </a>
-          </div>
+          <a
+            :href="page.pageUrl"
+            class="page-url"
+            target="_blank"
+            rel="noopener"
+          >
+            {{ page.pageUrl }}
+            <span class="sr-only">(nouvelle fenêtre)</span>
+          </a>
 
           <div
             v-for="(topic, i) in page.topics"
             :key="topic.topic"
-            :class="{ 'fr-mt-9v': i !== 0 }"
+            :class="i === 0 ? 'fr-mt-4w' : 'fr-mt-9v'"
           >
             <p class="fr-tag fr-tag--sm fr-mb-3w">
               {{ topic.name }}

--- a/confiture-web-app/yarn.lock
+++ b/confiture-web-app/yarn.lock
@@ -132,10 +132,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@gouvfr/dsfr@1.7.2":
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/@gouvfr/dsfr/-/dsfr-1.7.2.tgz#c522fce21a14989a10e30583160118c39c9c05d1"
-  integrity sha512-hPNtz+gHcc8m7ZPANxSOFMz4Ap+M9FHOudqoMR/+Kjl5FCOqwA6u/aoYnMJ8KqedS1k5XThFMp7jiktr53qXYw==
+"@gouvfr/dsfr@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@gouvfr/dsfr/-/dsfr-1.9.0.tgz#5d6b97328b8c239d0d4383708a5fa59fd5290e4c"
+  integrity sha512-CWckBrvCL28QV2K1+GK/AjW40aGHmd1oXnCSFRD4iRhsIgXkE/+t6pH24L+6BKVBCSYfp2RTGAgRwVN06PqGMw==
 
 "@humanwhocodes/config-array@^0.11.6":
   version "0.11.8"


### PR DESCRIPTION
A priori pas de changements majeurs, j'ai fait le tour de toutes les pages mais le changelog pour la 1.9.0 indique seulement des ajouts de fonctionnalités ou des corrections. Par contre celui de la 1.8.0 n'est pas disponible.

closes #315.