### PR TITLE
fix broken 'hide evaluated criteria' filter on fast audits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Tous les changements notables de Ara sont documentés ici avec leur date, leur c
 ### Correction 🐛
 
 - Corrige les onglets cassés lors de l'utilisation d'ancres ([#372](https://github.com/DISIC/Ara/pull/372))
+- Corrige le filtre "Masquer les critères évalués" qui ne fonctionnait pas sur les audits rapides et complémentaires ([#373](https://github.com/DISIC/Ara/pull/373))
 
 ## 04/05/2023
 

--- a/confiture-web-app/src/store/filters.ts
+++ b/confiture-web-app/src/store/filters.ts
@@ -41,11 +41,10 @@ export const useFiltersStore = defineStore("filters", {
               .map((c: any) => {
                 return {
                   ...c,
-                  status: resultStore.data
-                    ? resultStore.data[auditStore.currentPageId!][t.number][
-                        c.criterium.number
-                      ].status
-                    : null,
+                  status:
+                    resultStore.data?.[auditStore.currentPageId!]?.[t.number]?.[
+                      c.criterium.number
+                    ]?.status,
                 };
               })
               .filter((c: any) => {


### PR DESCRIPTION
Le filtre "Masquer les critères évalués" était cassé sur les audits rapides et complémentaires