### PR TITLE
add request and response payloads to sentry error context

### DIFF
--- a/confiture-web-app/src/components/AuditGenerationCriterium.vue
+++ b/confiture-web-app/src/components/AuditGenerationCriterium.vue
@@ -19,7 +19,7 @@ import CriteriumTestsAccordion from "./CriteriumTestsAccordion.vue";
 import { useResultsStore, useFiltersStore } from "../store";
 import { useNotifications } from "../composables/useNotifications";
 import RadioGroup, { RadioColor } from "./RadioGroup.vue";
-import { captureException } from "@sentry/core";
+import { captureWithPayloads } from "../utils";
 
 const store = useResultsStore();
 const filtersStore = useFiltersStore();
@@ -109,7 +109,7 @@ function handleUploadExample(file: File) {
               "Le téléchargement de l'exemple a échoué",
               "Une erreur inconnue est survenue"
             );
-            captureException(error);
+            captureWithPayloads(error);
           }
         } else {
           notify(
@@ -117,7 +117,7 @@ function handleUploadExample(file: File) {
             "Téléchargement échoué",
             "Une erreur inconnue est survenue"
           );
-          captureException(error);
+          captureWithPayloads(error);
         }
       }
     });

--- a/confiture-web-app/src/components/AuditGenerationHeader.vue
+++ b/confiture-web-app/src/components/AuditGenerationHeader.vue
@@ -2,11 +2,10 @@
 import { computed, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
-import { captureException } from "@sentry/vue";
 import { useDevMode } from "../composables/useDevMode";
 import { useNotifications } from "../composables/useNotifications";
 import { useAuditStore, useResultsStore } from "../store";
-import { formatDate } from "../utils";
+import { captureWithPayloads, formatDate } from "../utils";
 import Dropdown from "./Dropdown.vue";
 import SummaryCard from "./SummaryCard.vue";
 import DeleteModal from "./DeleteModal.vue";
@@ -57,7 +56,7 @@ function confirmDelete() {
         "Une erreur est survenue",
         "Un problème empêche la sauvegarde de vos données. Contactez-nous à l'adresse contact@design.numerique.gouv.fr si le problème persiste."
       );
-      captureException(error);
+      captureWithPayloads(error);
     })
     .finally(() => {
       deleteModal.value?.hide();

--- a/confiture-web-app/src/composables/useWrappedFetch.ts
+++ b/confiture-web-app/src/composables/useWrappedFetch.ts
@@ -1,7 +1,7 @@
 import { onMounted } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { TimeoutError } from "ky";
-import { captureException } from "@sentry/vue";
+import { captureWithPayloads } from "../utils";
 
 /**
  * Hook wrapping a function returning a promise. If the function fails with
@@ -35,7 +35,7 @@ export function useWrappedFetch(func: () => Promise<unknown>) {
         },
       });
 
-      captureException(error);
+      captureWithPayloads(error);
     });
   });
 }

--- a/confiture-web-app/src/pages/edit/EditAuditStepThreePage.vue
+++ b/confiture-web-app/src/pages/edit/EditAuditStepThreePage.vue
@@ -12,9 +12,8 @@ import { useWrappedFetch } from "../../composables/useWrappedFetch";
 import rgaa from "../../criteres.json";
 import { useAuditStore, useResultsStore } from "../../store";
 import { AuditType, CriteriumResultStatus } from "../../types";
-import { getCriteriaCount } from "../../utils";
+import { captureWithPayloads, getCriteriaCount } from "../../utils";
 import { CRITERIA_BY_AUDIT_TYPE } from "../../criteria";
-import { captureException } from "@sentry/core";
 
 const route = useRoute();
 const router = useRouter();
@@ -45,7 +44,7 @@ function toStepFour() {
         "Une erreur est survenue",
         "Un problème empêche la sauvegarde de vos données. Contactez-nous à l'adresse contact@design.numerique.gouv.fr si le problème persiste."
       );
-      captureException(error);
+      captureWithPayloads(error);
     });
 }
 

--- a/confiture-web-app/src/pages/edit/NewAuditStepOnePage.vue
+++ b/confiture-web-app/src/pages/edit/NewAuditStepOnePage.vue
@@ -9,7 +9,7 @@ import router from "../../router";
 import { CreateAuditRequestData } from "../../types";
 import { useAuditStore } from "../../store";
 import { useNotifications } from "../../composables/useNotifications";
-import { captureException } from "@sentry/core";
+import { captureWithPayloads } from "../../utils";
 
 const leaveModalRef = ref<InstanceType<typeof LeaveModal>>();
 const leaveModalDestination = ref<string>("");
@@ -76,7 +76,7 @@ function submitStepOne(data: CreateAuditRequestData) {
         "Une erreur est survenue",
         "Un problème empêche la sauvegarde de vos données. Contactez-nous à l'adresse contact@design.numerique.gouv.fr si le problème persiste."
       );
-      captureException(err);
+      captureWithPayloads(err);
     })
     .finally(() => {
       isSubmitting.value = false;


### PR DESCRIPTION
Cela nous permettra de plus facilement reproduire les erreurs rapportés par Sentry en ajoutant le payload de la requête à l'origine de l'erreur sur le rapport Sentry.

<img width="958" alt="Exemple de payload de requête sur Sentry.io" src="https://user-images.githubusercontent.com/7683740/236473187-ea3c6cc0-928a-45a3-84ba-ea453a428a42.png">
