### PR TITLE
Renseigne les meta des pages de compte

### DIFF
--- a/confiture-rest-api/src/mail/mail.service.ts
+++ b/confiture-rest-api/src/mail/mail.service.ts
@@ -106,8 +106,6 @@ export class MailService {
       token,
     )}`;
 
-    console.log(verificationLink)
-
     return this.sendMail(username, EmailType.ACCOUNT_VERIFICATION, {
       verificationLink,
     });

--- a/confiture-rest-api/src/mail/mail.service.ts
+++ b/confiture-rest-api/src/mail/mail.service.ts
@@ -106,6 +106,8 @@ export class MailService {
       token,
     )}`;
 
+    console.log(verificationLink)
+
     return this.sendMail(username, EmailType.ACCOUNT_VERIFICATION, {
       verificationLink,
     });

--- a/confiture-web-app/src/pages/account/AccountDashboardPage.vue
+++ b/confiture-web-app/src/pages/account/AccountDashboardPage.vue
@@ -6,6 +6,7 @@ import { useAccountStore } from "../../store/account";
 import { useAuditStore } from "../../store/audit";
 import TopLink from "../../components/TopLink.vue";
 import AuditsList from "../../components/account/dashboard/AuditsList.vue";
+import PageMeta from "../../components/PageMeta";
 import { history } from "../../router";
 
 const accountStore = useAccountStore();
@@ -45,6 +46,8 @@ onMounted(() => {
 </script>
 
 <template>
+  <PageMeta title="Mes audits" />
+
   <!-- Reset password alert -->
   <div
     v-if="showResetPasswordAlert"

--- a/confiture-web-app/src/pages/account/AccountDeletionFeedback.vue
+++ b/confiture-web-app/src/pages/account/AccountDeletionFeedback.vue
@@ -2,6 +2,7 @@
 import { ref } from "vue";
 
 import greenCheck from "../../assets/images/green-check.svg";
+import PageMeta from "../../components/PageMeta";
 import { useAccountStore } from "../../store/account";
 
 const accountStore = useAccountStore();
@@ -16,6 +17,7 @@ function submitFeedback() {
 }
 </script>
 <template>
+  <PageMeta title="Compte supprimé avec succès" />
   <div aria-live="polite" aria-atomic="true" role="alert">
     <template v-if="showSuccess">
       <p class="fr-h3 success-title">

--- a/confiture-web-app/src/pages/account/AccountSettingsPage.vue
+++ b/confiture-web-app/src/pages/account/AccountSettingsPage.vue
@@ -7,6 +7,7 @@ import Account from "../../components/account/settings/Account.vue";
 import Password from "../../components/account/settings/Password.vue";
 import Email from "../../components/account/settings/Email.vue";
 import TopLink from "../../components/TopLink.vue";
+import PageMeta from "../../components/PageMeta";
 
 import { useAccountStore } from "../../store/account";
 
@@ -18,6 +19,8 @@ onMounted(() => {
 </script>
 
 <template>
+  <PageMeta title="Mon compte" />
+
   <div class="fr-container">
     <div class="fr-grid-row">
       <div class="fr-col-12 fr-col-lg-3">

--- a/confiture-web-app/src/pages/account/LoginPage.vue
+++ b/confiture-web-app/src/pages/account/LoginPage.vue
@@ -5,6 +5,7 @@ import { useRouter } from "vue-router";
 import { useAccountStore } from "../../store/account";
 import { history } from "../../router";
 import DsfrField from "../../components/DsfrField.vue";
+import PageMeta from "../../components/PageMeta";
 import { useNotifications } from "../../composables/useNotifications";
 import { HTTPError } from "ky";
 import { captureWithPayloads } from "../../utils";
@@ -66,6 +67,7 @@ async function handleSubmit() {
 </script>
 
 <template>
+  <PageMeta title="Connexion" />
   <!-- TODO: fix top spacing -->
   <div
     v-if="showPasswordResetAlert || showCreatedAccountAlert"

--- a/confiture-web-app/src/pages/account/MissingAuditPage.vue
+++ b/confiture-web-app/src/pages/account/MissingAuditPage.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
 import { useAccountStore } from "../../store/account";
+import PageMeta from "../../components/PageMeta";
 
 const accountStore = useAccountStore();
 </script>
 
 <template>
+  <PageMeta title="Audit manquant ?" />
   <div class="fr-mb-4w">
     <RouterLink
       :to="{ name: 'account-dashboard' }"

--- a/confiture-web-app/src/pages/account/NewAccountPage.vue
+++ b/confiture-web-app/src/pages/account/NewAccountPage.vue
@@ -4,6 +4,7 @@ import { useAccountStore } from "../../store/account";
 import NewAccountForm from "../../components/account/new-acccount/NewAccountForm.vue";
 import EmailSent from "../../components/account/new-acccount/EmailSent.vue";
 import Success from "../../components/account/new-acccount/Success.vue";
+import PageMeta from "../../components/PageMeta";
 import { onBeforeRouteLeave } from "vue-router";
 
 const currentStep = ref(0);
@@ -41,6 +42,7 @@ onBeforeRouteLeave(() => {
 </script>
 
 <template>
+  <PageMeta title="Créer votre compte Ara" />
   <NewAccountForm v-if="currentStep === 0" @submit="handleSubmit" />
   <EmailSent
     v-else-if="currentStep === 1"

--- a/confiture-web-app/src/pages/account/NewAccountValidationPage.vue
+++ b/confiture-web-app/src/pages/account/NewAccountValidationPage.vue
@@ -8,6 +8,7 @@ import { useAccountStore } from "../../store/account";
 import { AccountVerificationJwtPayload } from "../../types";
 import { HTTPError } from "ky";
 import { useNotifications } from "../../composables/useNotifications";
+import PageMeta from "../../components/PageMeta";
 
 const route = useRoute();
 const store = useAccountStore();
@@ -46,6 +47,7 @@ onMounted(async () => {
 </script>
 
 <template>
+  <PageMeta title="Valider votre compte Ara" />
   <template v-if="tokenIsInvalid">
     <div class="wrapper">
       <div class="fr-mb-3w title">

--- a/confiture-web-app/src/pages/account/ResetPasswordPage.vue
+++ b/confiture-web-app/src/pages/account/ResetPasswordPage.vue
@@ -5,6 +5,7 @@ import { useRoute, useRouter } from "vue-router";
 import NewPasswordForm from "../../components/account/password-reset/NewPasswordForm.vue";
 import ResetInstructions from "../../components/account/password-reset/ResetInstructions.vue";
 import RequestPasswordReset from "../../components/account/password-reset/RequestPasswordReset.vue";
+import PageMeta from "../../components/PageMeta";
 
 import { useAccountStore } from "../../store/account";
 import { captureWithPayloads } from "../../utils";
@@ -91,6 +92,7 @@ async function resetPassword(newPassword: string) {
 </script>
 
 <template>
+  <PageMeta title="Réinitialiser le mot de passe" />
   <RequestPasswordReset
     v-if="currentStep === 0"
     ref="requestPasswordResetRef"

--- a/confiture-web-app/src/pages/account/UpdateEmailValidationPage.vue
+++ b/confiture-web-app/src/pages/account/UpdateEmailValidationPage.vue
@@ -8,6 +8,7 @@ import { useAccountStore } from "../../store/account";
 import { HTTPError } from "ky";
 import { useNotifications } from "../../composables/useNotifications";
 import { NewEmailVerificationJwtPayload } from "../../types";
+import PageMeta from "../../components/PageMeta";
 
 const route = useRoute();
 const store = useAccountStore();
@@ -59,6 +60,7 @@ onMounted(async () => {
 </script>
 
 <template>
+  <PageMeta title="Mettre à jour l’adresse e-mail" />
   <!-- Failure page -->
   <template v-if="tokenIsInvalid">
     <div class="wrapper">

--- a/confiture-web-app/src/router.ts
+++ b/confiture-web-app/src/router.ts
@@ -153,16 +153,32 @@ const router = createRouter({
       },
     },
     // Account pages
-    // TODO: add meta
     {
       path: "/compte/nouveau",
       name: "new-account",
       component: NewAccountPage,
+      meta: {
+        name: "Créer votre compte Ara",
+        breadcrumbLinks: () => [
+          getHomeBreadcrumbLink(),
+          { label: "Créer votre compte Ara", name: "new-account" },
+        ],
+      },
     },
     {
       path: "/compte/validation",
       name: "new-account-validation",
       component: NewAccountValidationPage,
+      meta: {
+        name: "Valider votre compte Ara",
+        breadcrumbLinks: () => [
+          getHomeBreadcrumbLink(),
+          {
+            label: "Valider votre compte Ara",
+            name: "new-account-validation",
+          },
+        ],
+      },
     },
     {
       path: "/compte/email-update-validation",
@@ -183,11 +199,24 @@ const router = createRouter({
       path: "/compte/connexion",
       name: "login",
       component: LoginPage,
+      meta: {
+        name: "Connexion à Ara",
+        breadcrumbLinks: () => [
+          getHomeBreadcrumbLink(),
+          {
+            label: "Connexion à Ara",
+            name: "login",
+          },
+        ],
+      },
     },
     {
       path: "/compte/reinitialiser-mot-de-passe",
       name: "password-reset",
       component: ResetPasswordPage,
+      meta: {
+        name: "Réinitialiser votre mot de passe",
+      },
     },
     {
       path: "/compte",
@@ -196,6 +225,13 @@ const router = createRouter({
       meta: {
         name: "Mes audits",
         authRequired: true,
+        breadcrumbLinks: () => [
+          getHomeBreadcrumbLink(),
+          {
+            label: "Mes audits",
+            name: "account-dashboard",
+          },
+        ],
       },
     },
     {


### PR DESCRIPTION
Pour chaque page, il y a 2 infos à renseigner :
- Le titre de la page (`title`, visible dans l'onglet par exemple)
- Le label du lien du fil d'Ariane (quand ce dernier est affiché sur la page)