### PR TITLE
include user profile in jwt to simplify profile reads and writes

### DIFF
--- a/confiture-rest-api/src/auth/auth.service.ts
+++ b/confiture-rest-api/src/auth/auth.service.ts
@@ -10,7 +10,6 @@ import {
   NewEmailVerificationJwtPayload,
   RequestPasswordResetJwtPayload,
 } from './jwt-payloads';
-import { RequestPasswordResetDto } from './dto/request-password-reset.dto';
 
 export class UsernameAlreadyExistsError extends Error {
   readonly username: string;
@@ -174,6 +173,8 @@ export class AuthService {
     const payload: AuthenticationJwtPayload = {
       sub: user.uid,
       email: user.username,
+      name: user.name,
+      org: user.orgName,
     };
     const token = await this.jwt.signAsync(payload, { expiresIn: '24h' });
 
@@ -192,6 +193,8 @@ export class AuthService {
     const payload: AuthenticationJwtPayload = {
       sub: user.uid,
       email: user.username,
+      name: user.name,
+      org: user.orgName,
     };
     const token = await this.jwt.signAsync(payload, { expiresIn: '24h' });
     return token;

--- a/confiture-rest-api/src/auth/jwt-payloads.ts
+++ b/confiture-rest-api/src/auth/jwt-payloads.ts
@@ -4,6 +4,12 @@ export interface AuthenticationJwtPayload {
 
   /** User email */
   email: string;
+
+  /** User full name */
+  name: string | null;
+
+  /** User organization. */
+  org: string | null;
 }
 
 export interface AccountVerificationJwtPayload {

--- a/confiture-rest-api/src/profile/profile.controller.ts
+++ b/confiture-rest-api/src/profile/profile.controller.ts
@@ -1,35 +1,22 @@
-import {
-  Body,
-  Controller,
-  Get,
-  Patch,
-  UnauthorizedException,
-} from '@nestjs/common';
-import {
-  ApiGoneResponse,
-  ApiNotFoundResponse,
-  ApiOkResponse,
-  ApiTags,
-  ApiUnauthorizedResponse,
-} from '@nestjs/swagger';
+import { Body, Controller, Patch, UnauthorizedException } from '@nestjs/common';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
 import { AuthRequired } from '../auth/auth-required.decorator';
 import { AuthenticationJwtPayload } from '../auth/jwt-payloads';
 import { User } from '../auth/user.decorator';
-import { ProfileService } from './profile.service';
-import { User as UserDto } from '../generated/nestjs-dto/user.entity';
 import { PatchProfileDto } from './patch-profile.dto';
+import { ProfileService } from './profile.service';
 
 @Controller('profile')
 @ApiTags('User Profile')
 export class ProfileController {
   constructor(private readonly profileService: ProfileService) {}
 
-  @Get()
-  @AuthRequired()
-  @ApiOkResponse({ type: UserDto })
-  getProfile(@User() user: AuthenticationJwtPayload) {
-    return this.profileService.getUserProfile(user.email);
-  }
+  // @Get()
+  // @AuthRequired()
+  // @ApiOkResponse({ type: UserDto })
+  // getProfile(@User() user: AuthenticationJwtPayload) {
+  //   return this.profileService.getUserProfile(user.email);
+  // }
 
   /**
    * Patch a user profile.
@@ -51,7 +38,5 @@ export class ProfileController {
     if (!userProfile) {
       throw new UnauthorizedException();
     }
-
-    return userProfile;
   }
 }

--- a/confiture-rest-api/src/profile/profile.controller.ts
+++ b/confiture-rest-api/src/profile/profile.controller.ts
@@ -11,13 +11,6 @@ import { ProfileService } from './profile.service';
 export class ProfileController {
   constructor(private readonly profileService: ProfileService) {}
 
-  // @Get()
-  // @AuthRequired()
-  // @ApiOkResponse({ type: UserDto })
-  // getProfile(@User() user: AuthenticationJwtPayload) {
-  //   return this.profileService.getUserProfile(user.email);
-  // }
-
   /**
    * Patch a user profile.
    */

--- a/confiture-web-app/src/App.vue
+++ b/confiture-web-app/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { provide, ref, watch } from "vue";
+import { onMounted, provide, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 import { useHead } from "@unhead/vue";
 
@@ -8,6 +8,7 @@ import ToastNotification from "./components/ToastNotification.vue";
 import SiteHeader from "./components/SiteHeader.vue";
 import SiteFooter from "./components/SiteFooter.vue";
 import MarkdownHelpModal from "./components/MarkdownHelpModal.vue";
+import { useAccountStore } from "./store/account";
 
 const route = useRoute();
 
@@ -50,6 +51,13 @@ const markdownHelpModal = ref<InstanceType<typeof MarkdownHelpModal>>();
 
 provide("openMarkdownHelp", () => {
   markdownHelpModal.value?.show();
+});
+
+const accountStore = useAccountStore();
+onMounted(() => {
+  if (accountStore.authToken) {
+    accountStore.refreshToken();
+  }
 });
 </script>
 

--- a/confiture-web-app/src/components/account/settings/Profile.vue
+++ b/confiture-web-app/src/components/account/settings/Profile.vue
@@ -31,7 +31,10 @@ const showActions = computed(() => {
 
 function updateProfile() {
   accountStore
-    .updateProfile({ name: name.value, orgName: orgName.value })
+    .updateProfile({
+      name: name.value || null,
+      orgName: orgName.value || null,
+    })
     .then(() => {
       notify("success", "Profil mis à jour avec succès");
     })

--- a/confiture-web-app/src/pages/account/AccountSettingsPage.vue
+++ b/confiture-web-app/src/pages/account/AccountSettingsPage.vue
@@ -1,6 +1,4 @@
 <script lang="ts" setup>
-import { onMounted } from "vue";
-
 import Sidebar from "../../components/account/settings/Sidebar.vue";
 import Profile from "../../components/account/settings/Profile.vue";
 import Account from "../../components/account/settings/Account.vue";
@@ -8,14 +6,6 @@ import Password from "../../components/account/settings/Password.vue";
 import Email from "../../components/account/settings/Email.vue";
 import TopLink from "../../components/TopLink.vue";
 import PageMeta from "../../components/PageMeta";
-
-import { useAccountStore } from "../../store/account";
-
-const accountStore = useAccountStore();
-
-onMounted(() => {
-  accountStore.getProfile();
-});
 </script>
 
 <template>

--- a/confiture-web-app/src/types/account.ts
+++ b/confiture-web-app/src/types/account.ts
@@ -9,9 +9,9 @@ export interface Account {
 
 export interface UpdateProfileRequestData {
   /** John Doe */
-  name?: string;
+  name: string | null;
   /** ACME */
-  orgName?: string;
+  orgName: string | null;
 }
 
 export interface AccountDeletionResponse {

--- a/confiture-web-app/src/types/index.ts
+++ b/confiture-web-app/src/types/index.ts
@@ -6,6 +6,11 @@ export interface AuthenticationJwtPayload {
   sub: string;
   /** User email */
   email: string;
+  /** User full name */
+  name: string | null;
+  /** User organization. */
+  org: string | null;
+
   /** Issued at */
   iat: number;
   /** Expiration date */


### PR DESCRIPTION
Simplifie la gestion du profil utilisateur en incluant les informations de profil dans le token JWT. La propriété `accountStore.account` est remplacée par un getter qui décode le token.