### PR TITLE
Annonce le changement de page aux techno d'assistance

### DIFF
--- a/confiture-web-app/src/App.vue
+++ b/confiture-web-app/src/App.vue
@@ -62,6 +62,9 @@ onMounted(() => {
 </script>
 
 <template>
+  <!-- Page title container, filled on page change -->
+  <div id="page-title-alert" class="sr-only" role="alert" aria-live="polite" />
+
   <div class="fr-skiplinks">
     <nav class="fr-container" role="navigation" aria-label="Accès rapide">
       <ul class="fr-skiplinks__list">

--- a/confiture-web-app/src/router.ts
+++ b/confiture-web-app/src/router.ts
@@ -9,7 +9,6 @@ import NewAuditStepOnePage from "./pages/edit/NewAuditStepOnePage.vue";
 import FeedbackPage from "./pages/FeedbackPage.vue";
 import AccessibilityPlanPage from "./pages/help/AccessibilityPlanPage.vue";
 import AccessibilityStatementPage from "./pages/help/AccessibilityStatementPage.vue";
-import HelpPage from "./pages/help/HelpPage.vue";
 import LegalRequirementsPage from "./pages/help/LegalRequirementsPage.vue";
 import RGAAPage from "./pages/help/RGAAPage.vue";
 import HomePage from "./pages/HomePage.vue";
@@ -610,6 +609,20 @@ router.beforeEach((to) => {
   const accountStore = useAccountStore();
   if (to.meta.authRequired && !accountStore.account) {
     return { name: "login" };
+  }
+});
+
+// Reset focus on <body> + announce new page title
+router.afterEach(async (to, from) => {
+  if (from.path !== to.path) {
+    const pageTitleAlert = document.querySelector("#page-title-alert");
+    if (pageTitleAlert) {
+      pageTitleAlert.innerHTML = `<p>${to.meta.name}</p>`;
+    }
+
+    document.body.setAttribute("tabindex", "-1");
+    document.body.focus();
+    document.body.removeAttribute("tabindex");
   }
 });
 

--- a/confiture-web-app/src/router.ts
+++ b/confiture-web-app/src/router.ts
@@ -618,6 +618,10 @@ router.afterEach(async (to, from) => {
     const pageTitleAlert = document.querySelector("#page-title-alert");
     if (pageTitleAlert) {
       pageTitleAlert.innerHTML = `<p>${to.meta.name}</p>`;
+
+      setTimeout(() => {
+        pageTitleAlert.innerHTML = "";
+      }, 2000);
     }
 
     document.body.setAttribute("tabindex", "-1");


### PR DESCRIPTION
- Remet le focus sur le `<body>` à chaque changement de page.
- Annonce le titre de la nouvelle page (ajouter un `aria-label` sur le `<body>` ne semblait pas fonctionner, du coup j'ai ajouté une `<div>` cachée qui est remplie à chaque changement de page avec le nouveau titre).

#499 