### PR TITLE
Affiche uniquement le outline sur `:focus-visible`

### DIFF
--- a/confiture-web-app/src/components/account/dashboard/AuditRow.vue
+++ b/confiture-web-app/src/components/account/dashboard/AuditRow.vue
@@ -334,8 +334,8 @@ const csvExportFilename = computed(() => {
 .audit-name:focus {
   outline: none;
 }
-.audit-name:focus::before {
-  outline: 2px solid #0a76f6;
+.audit-name:focus-visible::before {
+  outline: 2px solid var(--dsfr-outline);
 }
 
 .audit-name::before {

--- a/confiture-web-app/src/components/audit/AraTabs.vue
+++ b/confiture-web-app/src/components/audit/AraTabs.vue
@@ -179,7 +179,7 @@ li {
   background-color: var(--active-tint);
 }
 
-.tabs button:focus {
+.tabs button:focus-visible {
   outline: 2px solid var(--dsfr-outline);
   outline-offset: -2px;
 }

--- a/confiture-web-app/src/components/audit/AuditGenerationFilters.vue
+++ b/confiture-web-app/src/components/audit/AuditGenerationFilters.vue
@@ -287,8 +287,8 @@ const notApplicableCount = computed(
   margin-bottom: 2rem;
 }
 
-.toggle-column-button:focus {
-  outline: 2px solid #0a76f6;
+.toggle-column-button:focus-visible {
+  outline: 2px solid var(--dsfr-outline);
   outline-offset: -2px;
 }
 

--- a/confiture-web-app/src/components/audit/CriteriumNotCompliantAccordion.vue
+++ b/confiture-web-app/src/components/audit/CriteriumNotCompliantAccordion.vue
@@ -260,7 +260,7 @@ const isOffline = useIsOffline();
 
 .upload-label {
   cursor: pointer;
-  outline-color: #0a76f6;
+  outline-color: var(--dsfr-outline);
   outline-offset: 2px;
   outline-width: 2px;
   outline-style: none;


### PR DESCRIPTION
Le focus sur le [composant du DSFR "Barre de recherche"](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/barre-de-recherche) semble afficher le focus même au clic à la souris. Ça n'est pas le cas pour les autres composants exceptés les champs (`input` et `textarea`).

Du coup est-ce qu'on l'override quand même @AdrienMuzyczka ?

Pour les autres c'est good, le focus s'affiche bien uniquement au clavier :
- Onglets de l'audit
- Bouton pour cacher/afficher les filtres
- Ligne de l'audit dans "Mes audits"

- [ ] ~Voir pour mettre un padding sur la sidebar des filters~

closes #629 