### PR TITLE
Fix integration issues on sidebar and FileUpload

### DIFF
--- a/confiture-web-app/src/components/audit/NotesModal.vue
+++ b/confiture-web-app/src/components/audit/NotesModal.vue
@@ -90,7 +90,7 @@ function handleDeleteFile(file: AuditFile) {
             <div class="fr-modal__content">
               <div class="sidebar-header">
                 <button
-                  class="fr-btn--close fr-btn"
+                  class="fr-btn--close fr-btn fr-text--md"
                   aria-controls="notes-modal"
                   type="button"
                 >
@@ -104,7 +104,7 @@ function handleDeleteFile(file: AuditFile) {
                 </div>
               </div>
               <div class="fr-input-group fr-mb-1v">
-                <label class="fr-label" for="audit-notes">
+                <label class="fr-label fr-text--bold" for="audit-notes">
                   Remarques et recommandations générales
                 </label>
                 <textarea
@@ -125,10 +125,11 @@ function handleDeleteFile(file: AuditFile) {
               <FileUpload
                 ref="fileUpload"
                 class="fr-mb-4w"
-                :disabled="isOffline"
                 :audit-files="files"
-                :multiple="true"
+                :bold-title="true"
+                :disabled="isOffline"
                 :error-message="errorMessage"
+                :multiple="true"
                 @upload-file="handleUploadFile"
                 @delete-file="handleDeleteFile"
               />
@@ -141,13 +142,17 @@ function handleDeleteFile(file: AuditFile) {
 </template>
 
 <style scoped>
+.fr-modal__content {
+  padding-left: 3rem;
+  padding-right: 3rem;
+}
 .sidebar-header {
   display: flex;
   flex-direction: row-reverse;
   flex-wrap: wrap;
   column-gap: 1rem;
   align-items: center;
-  margin: var(--title-spacing);
+  margin: 2rem 0 1.5rem 0;
   padding: 0.75rem 0;
   position: sticky;
   top: 0;
@@ -162,6 +167,11 @@ function handleDeleteFile(file: AuditFile) {
 .title-container {
   flex-basis: 100%;
 }
+
+textarea {
+  resize: vertical;
+}
+
 @media (min-width: 36em) {
   .title-container {
     display: flex;
@@ -169,7 +179,7 @@ function handleDeleteFile(file: AuditFile) {
     align-items: center;
   }
   .sidebar-header h1 {
-    border-right: solid var(--border-default-grey);
+    border-right: 1px solid var(--border-default-grey);
   }
 }
 </style>

--- a/confiture-web-app/src/components/ui/FileUpload.vue
+++ b/confiture-web-app/src/components/ui/FileUpload.vue
@@ -97,7 +97,7 @@ function getFullFileName(auditFile: AuditFile) {
 function getFileDetails(auditFile: AuditFile) {
   const name = auditFile.originalFilename;
   const extension = name.substring(name.lastIndexOf(".") + 1).toUpperCase();
-  return extension + " — " + formatBytes(auditFile.size);
+  return extension + " – " + formatBytes(auditFile.size);
 }
 
 function isViewable(auditFile: AuditFile) {
@@ -120,36 +120,34 @@ function onFileRequestFinished() {
           class="fr-label fr-upload-group__desc"
           :class="{ 'fr-text--bold': boldTitle }"
         >
-          {{ title }}<br />
-          <span class="fr-mt-1v fr-text--regular fr-hint-text"
-            ><span>Taille maximale par fichier&#8239;: {{ maxFileSize }}</span
-            ><span>. <span v-html="acceptedFormatsHtml"></span></span>
-            <span v-if="multiple">. Plusieurs fichiers possibles.</span></span
-          >
+          {{ title }}
+        </p>
+        <p class="fr-text--regular fr-hint-text fr-my-2v">
+          <span>Taille maximale par fichier&#8239;: {{ maxFileSize }}</span
+          ><span>. <span v-html="acceptedFormatsHtml"></span></span>
+          <span v-if="multiple">. Plusieurs fichiers possibles.</span>
         </p>
 
         <!-- TODO: handle multiple files upload -->
         <!-- :multiple="multiple ?? undefined" -->
-        <div class="upload-line fr-mt-2w fr-mb-2w">
-          <label
-            class="fr-btn fr-btn--tertiary"
-            tabindex="0"
-            :for="`file-upload-${id}`"
-            >Choisir un fichier</label
-          >
-          <input
-            :id="`file-upload-${id}`"
-            ref="fileInputRef"
-            class="fr-sr-only"
-            tabindex="-1"
-            type="file"
-            :accept="acceptedFormatsAttr"
-            :disabled="isOffline"
-            :aria-describedby="`file-upload-description-${id} file-upload-error-format-${id} file-upload-error-size-${id}`"
-            @change="handleFileChange"
-          />
-          <span>{{ selectedFiles }}</span>
-        </div>
+        <label
+          class="upload-btn fr-btn fr-btn--tertiary"
+          tabindex="0"
+          :for="`file-upload-${id}`"
+          >Choisir un fichier</label
+        >
+        <input
+          :id="`file-upload-${id}`"
+          ref="fileInputRef"
+          class="fr-sr-only"
+          tabindex="-1"
+          type="file"
+          :accept="acceptedFormatsAttr"
+          :disabled="isOffline"
+          :aria-describedby="`file-upload-description-${id} file-upload-error-format-${id} file-upload-error-size-${id}`"
+          @change="handleFileChange"
+        />
+        <p class="fr-text--sm fr-mt-3v fr-mb-2v">{{ selectedFiles }}</p>
       </div>
 
       <p
@@ -233,16 +231,10 @@ function onFileRequestFinished() {
   margin: 0;
 }
 
-.upload-line {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem 1rem;
-  align-items: center;
-}
-
 @media (hover: hover) and (pointer: fine) {
-  .upload-line .fr-btn:not(:disabled):hover:hover {
+  .upload-btn:not(:disabled):hover {
     background-color: var(--hover-tint);
+    cursor: pointer;
   }
 }
 
@@ -259,7 +251,7 @@ function onFileRequestFinished() {
   flex-wrap: wrap;
   gap: 1.5rem;
   align-items: center;
-  padding: 0.5rem;
+  padding: 0.75rem;
   border: 1px solid var(--artwork-motif-grey);
 }
 
@@ -275,7 +267,7 @@ function onFileRequestFinished() {
 
 .file-thumbnail,
 .file-thumbnail__default {
-  --thumbnail-size: 4.5rem;
+  --thumbnail-size: 3rem;
   color: var(--artwork-motif-grey);
   background-color: var(--background-alt-blue-france);
   width: var(--thumbnail-size);
@@ -294,6 +286,6 @@ function onFileRequestFinished() {
 }
 
 .file-thumbnail__default::before {
-  --icon-size: 3rem;
+  --icon-size: 2.5rem;
 }
 </style>

--- a/confiture-web-app/src/components/ui/FileUpload.vue
+++ b/confiture-web-app/src/components/ui/FileUpload.vue
@@ -112,118 +112,116 @@ function onFileRequestFinished() {
 </script>
 
 <template>
-  <div>
-    <div class="upload-wrapper">
-      <div v-if="!readonly" class="fr-upload-group">
-        <p
-          :id="`file-upload-description-${id}`"
-          class="fr-label fr-upload-group__desc"
-          :class="{ 'fr-text--bold': boldTitle }"
-        >
-          {{ title }}
-        </p>
-        <p class="fr-text--regular fr-hint-text fr-my-2v">
-          <span>Taille maximale par fichier&#8239;: {{ maxFileSize }}</span
-          ><span>. <span v-html="acceptedFormatsHtml"></span></span>
-          <span v-if="multiple">. Plusieurs fichiers possibles.</span>
-        </p>
-
-        <!-- TODO: handle multiple files upload -->
-        <!-- :multiple="multiple ?? undefined" -->
-        <label
-          class="upload-btn fr-btn fr-btn--tertiary"
-          tabindex="0"
-          :for="`file-upload-${id}`"
-          >Choisir un fichier</label
-        >
-        <input
-          :id="`file-upload-${id}`"
-          ref="fileInputRef"
-          class="fr-sr-only"
-          tabindex="-1"
-          type="file"
-          :accept="acceptedFormatsAttr"
-          :disabled="isOffline"
-          :aria-describedby="`file-upload-description-${id} file-upload-error-format-${id} file-upload-error-size-${id}`"
-          @change="handleFileChange"
-        />
-        <p class="fr-text--sm fr-mt-3v fr-mb-2v">{{ selectedFiles }}</p>
-      </div>
-
+  <div class="upload-wrapper">
+    <div v-if="!readonly" class="fr-upload-group">
       <p
-        v-if="errorMessage || localErrorMessage"
-        :id="`file-upload-error-format-${id}`"
-        class="fr-error-text fr-mt-0"
+        :id="`file-upload-description-${id}`"
+        class="fr-label fr-upload-group__desc"
+        :class="{ 'fr-text--bold': boldTitle }"
       >
-        {{ errorMessage ? errorMessage : localErrorMessage }}
+        {{ title }}
       </p>
+      <p class="fr-text--regular fr-hint-text fr-my-2v">
+        <span>Taille maximale par fichier&#8239;: {{ maxFileSize }}</span
+        ><span>. <span v-html="acceptedFormatsHtml"></span></span>
+        <span v-if="multiple">. Plusieurs fichiers possibles.</span>
+      </p>
+
+      <!-- TODO: handle multiple files upload -->
+      <!-- :multiple="multiple ?? undefined" -->
+      <label
+        class="upload-btn fr-btn fr-btn--tertiary"
+        tabindex="0"
+        :for="`file-upload-${id}`"
+        >Choisir un fichier</label
+      >
+      <input
+        :id="`file-upload-${id}`"
+        ref="fileInputRef"
+        class="fr-sr-only"
+        tabindex="-1"
+        type="file"
+        :accept="acceptedFormatsAttr"
+        :disabled="isOffline"
+        :aria-describedby="`file-upload-description-${id} file-upload-error-format-${id} file-upload-error-size-${id}`"
+        @change="handleFileChange"
+      />
+      <p class="fr-text--sm fr-mt-3v fr-mb-2v">{{ selectedFiles }}</p>
     </div>
 
-    <!-- Audit files -->
-    <ul class="files">
-      <li v-for="auditFile in auditFiles" :key="auditFile.id">
-        <img
-          v-if="auditFile.thumbnailKey"
-          class="fr-icon--lg file-thumbnail"
-          :src="getUploadUrl(auditFile.thumbnailKey)"
-          alt=""
-          loading="lazy"
-          width="80"
-          height="80"
-        />
-        <span
-          v-else
-          class="fr-icon--lg file-thumbnail__default fr-icon-file-text-line"
-          loading="lazy"
-        >
-        </span>
-        <div class="file-link">
-          <span>{{ getFileName(auditFile) }}</span
-          ><br />
-          <span class="fr-hint-text">{{ getFileDetails(auditFile) }}</span>
-        </div>
-        <ul class="fr-btns-group fr-btns-group--inline">
-          <li v-if="isViewable(auditFile)">
-            <a
-              class="fr-btn fr-btn fr-btn--tertiary-no-outline fr-icon-eye-line fr-mb-0"
-              :href="getUploadUrl(auditFile.key)"
-              :disabled="isOffline"
-              target="_blank"
-              :title="
-                'Voir ' + getFullFileName(auditFile) + ' - nouvelle fenêtre'
-              "
-            >
-              Voir
-              <span class="sr-only">{{ getFullFileName(auditFile) }}</span>
-            </a>
-          </li>
-          <li>
-            <a
-              class="fr-btn fr-btn--tertiary-no-outline fr-icon-download-line fr-mb-0"
-              download
-              :href="getUploadUrl(auditFile.key)"
-              :disabled="isOffline"
-              :title="'Télécharger ' + getFullFileName(auditFile)"
-            >
-              Télécharger
-              <span class="sr-only">{{ getFullFileName(auditFile) }}</span>
-            </a>
-          </li>
-          <li v-if="!readonly">
-            <button
-              class="fr-btn fr-btn--tertiary-no-outline fr-icon-delete-bin-line fr-mb-0"
-              :disabled="isOffline"
-              :title="'Supprimer ' + getFullFileName(auditFile)"
-              @click="deleteFile(auditFile)"
-            >
-              Supprimer
-              <span class="sr-only">{{ getFullFileName(auditFile) }}</span>
-            </button>
-          </li>
-        </ul>
-      </li>
-    </ul>
+    <p
+      v-if="errorMessage || localErrorMessage"
+      :id="`file-upload-error-format-${id}`"
+      class="fr-error-text fr-mt-0"
+    >
+      {{ errorMessage ? errorMessage : localErrorMessage }}
+    </p>
   </div>
+
+  <!-- Audit files -->
+  <ul class="files">
+    <li v-for="auditFile in auditFiles" :key="auditFile.id">
+      <img
+        v-if="auditFile.thumbnailKey"
+        class="fr-icon--lg file-thumbnail"
+        :src="getUploadUrl(auditFile.thumbnailKey)"
+        alt=""
+        loading="lazy"
+        width="80"
+        height="80"
+      />
+      <span
+        v-else
+        class="fr-icon--lg file-thumbnail__default fr-icon-file-text-line"
+        loading="lazy"
+      >
+      </span>
+      <div class="file-link">
+        <span>{{ getFileName(auditFile) }}</span
+        ><br />
+        <span class="fr-hint-text">{{ getFileDetails(auditFile) }}</span>
+      </div>
+      <ul class="fr-btns-group fr-btns-group--inline">
+        <li v-if="isViewable(auditFile)">
+          <a
+            class="fr-btn fr-btn fr-btn--tertiary-no-outline fr-icon-eye-line fr-mb-0"
+            :href="getUploadUrl(auditFile.key)"
+            :disabled="isOffline"
+            target="_blank"
+            :title="
+              'Voir ' + getFullFileName(auditFile) + ' - nouvelle fenêtre'
+            "
+          >
+            Voir
+            <span class="sr-only">{{ getFullFileName(auditFile) }}</span>
+          </a>
+        </li>
+        <li>
+          <a
+            class="fr-btn fr-btn--tertiary-no-outline fr-icon-download-line fr-mb-0"
+            download
+            :href="getUploadUrl(auditFile.key)"
+            :disabled="isOffline"
+            :title="'Télécharger ' + getFullFileName(auditFile)"
+          >
+            Télécharger
+            <span class="sr-only">{{ getFullFileName(auditFile) }}</span>
+          </a>
+        </li>
+        <li v-if="!readonly">
+          <button
+            class="fr-btn fr-btn--tertiary-no-outline fr-icon-delete-bin-line fr-mb-0"
+            :disabled="isOffline"
+            :title="'Supprimer ' + getFullFileName(auditFile)"
+            @click="deleteFile(auditFile)"
+          >
+            Supprimer
+            <span class="sr-only">{{ getFullFileName(auditFile) }}</span>
+          </button>
+        </li>
+      </ul>
+    </li>
+  </ul>
 </template>
 
 <style scoped>

--- a/confiture-web-app/src/components/ui/FileUpload.vue
+++ b/confiture-web-app/src/components/ui/FileUpload.vue
@@ -122,9 +122,9 @@ function onFileRequestFinished() {
         {{ title }}
       </p>
       <p class="fr-text--regular fr-hint-text fr-my-2v">
-        <span>Taille maximale par fichier&#8239;: {{ maxFileSize }}</span
-        ><span>. <span v-html="acceptedFormatsHtml"></span></span>
-        <span v-if="multiple">. Plusieurs fichiers possibles.</span>
+        Taille maximale par fichier&#8239;: {{ maxFileSize }}.
+        <span v-html="acceptedFormatsHtml"></span>
+        <template v-if="multiple">. Plusieurs fichiers possibles.</template>
       </p>
 
       <!-- TODO: handle multiple files upload -->


### PR DESCRIPTION
- Amincir le séparateur à droite du titre "Annotations de l’audit" (1px au lieu de 2.5px)
- Agrandir la marge tout autour de la sidebar (48px)
- Rétrécir le texte "Fichiers ajoutés" (fr-text--sm)
- Rétrécir en hauteur les lignes de chaque fichier ajouté (72px de hauteur, l’icône faisant 48px de hauteur)
- Passer le nombre de fichiers ajoutés sous le bouton (margin-top: 12px, margin-bottom: 8px)
- Passer les étiquettes des 2 champs en gras
- Augmenter la taille du bouton fermer (fr-text--md)
- Bloquer la possibilité de redimensionner la zone de texte verticalement