### PR TITLE
Ajoute un attribut `autocomplete` sur le champ email du formulaire de connexion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Tous les changements notables de Ara sont documentés ici avec leur date, leur catégorie (nouvelle fonctionnalité, correction de bug ou autre changement) et leur pull request (PR) associée.
 
+## 09/10/2024
+
+### Corrections 🐛
+
+- Corrige l’application de l'attribut `autocomplete` sur le champ "email" du formulaire de connexion ([#808](https://github.com/DISIC/Ara/pull/808))
+
 ## 05/09/2024
 
 ### Nouvelles fonctionnalités 🚀

--- a/confiture-web-app/src/components/ui/DsfrField.vue
+++ b/confiture-web-app/src/components/ui/DsfrField.vue
@@ -11,6 +11,7 @@ const props = defineProps<{
   title?: string;
   error?: string;
   id: string;
+  autocomplete?: string;
 }>();
 
 defineEmits<{
@@ -43,6 +44,7 @@ defineExpose({ inputRef });
       :required="required"
       :pattern="pattern ? pattern.toString().slice(1, -1) : undefined"
       :title="title"
+      :autocomplete="autocomplete"
       :value="modelValue"
       @input="
         $emit('update:modelValue', ($event.target as HTMLInputElement).value)

--- a/confiture-web-app/src/pages/account/LoginPage.vue
+++ b/confiture-web-app/src/pages/account/LoginPage.vue
@@ -142,6 +142,7 @@ async function handleSubmit() {
         hint="Format attendu : nom@domaine.fr"
         type="email"
         required
+        autocomplete="email"
         :error="userEmailError"
       />
 


### PR DESCRIPTION
Tous les attributs `autocomplete` étaient bien présent (sauf pour l'email) mais pas bindés via le composant `<DsfrField />` 😭 

closes #807 