### PR TITLE
fix(tiptap): do not render HTML, put back editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Tous les changements notables de Ara sont documentés ici avec leur date, leur catégorie (nouvelle fonctionnalité, correction de bug ou autre changement) et leur pull request (PR) associée.
 
+## 28/04/2025
+
+### Corrections 🐛
+
+- Corrige l’affichage des commentaires dans le rapport ([#1091](https://github.com/DISIC/Ara/pull/1091))
+
 ## 24/04/2025
 
 ### Corrections 🐛

--- a/confiture-web-app/src/components/tiptap/TiptapEditor.vue
+++ b/confiture-web-app/src/components/tiptap/TiptapEditor.vue
@@ -33,6 +33,7 @@ function getContent() {
     try {
       jsonContent = JSON.parse(props.modelValue);
     } catch {
+      // not json, most likely markdown
       jsonContent = props.modelValue;
     }
   }

--- a/confiture-web-app/src/components/tiptap/TiptapRenderer.vue
+++ b/confiture-web-app/src/components/tiptap/TiptapRenderer.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { generateHTML } from "@tiptap/core";
+import { Editor, EditorContent, useEditor } from "@tiptap/vue-3";
 import hljs from "highlight.js";
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, ref, ShallowRef } from "vue";
 
 import { tiptapExtensions } from "./tiptap-extensions";
 
@@ -17,9 +17,11 @@ const parsedDocument = computed(() => {
   }
 });
 
-const html = computed(() => {
-  return generateHTML(parsedDocument.value, tiptapExtensions);
-});
+const editor = useEditor({
+  editable: false,
+  content: parsedDocument.value,
+  extensions: tiptapExtensions
+}) as ShallowRef<Editor>;
 
 const contentRef = ref<HTMLDivElement>();
 
@@ -31,7 +33,9 @@ onMounted(() => {
 </script>
 
 <template>
-  <div ref="contentRef" class="tiptap" v-html="html" />
+  <div ref="contentRef">
+    <editor-content :editor="editor" />
+  </div>
 </template>
 
 <style>

--- a/confiture-web-app/src/components/tiptap/TiptapRenderer.vue
+++ b/confiture-web-app/src/components/tiptap/TiptapRenderer.vue
@@ -18,6 +18,9 @@ const parsedDocument = computed(() => {
 });
 
 const editor = useEditor({
+  editorProps: {
+    attributes: { class: `tiptap--rendered` }
+  },
   editable: false,
   content: parsedDocument.value,
   extensions: tiptapExtensions

--- a/confiture-web-app/src/components/tiptap/tiptap.css
+++ b/confiture-web-app/src/components/tiptap/tiptap.css
@@ -7,6 +7,9 @@
   min-height: 10rem;
   padding: 0.5rem 0.75rem;
 }
+.tiptap--rendered {
+  min-height: inherit;
+}
 
 .tiptap img {
   cursor: pointer;


### PR DESCRIPTION
… in read-only mode.
Revert part of commit e2d66a8 (render html from tiptap json and organize tiptap files)

closes #1091

Avant de merger la pull request, s’assurer que :

- Les checks GitHub passent (lint...).
- Les tests Cypress ont été lancés en local (dans le cas d’une correction de bug ou d’une nouvelle fonctionnalité).
