### PR TITLE
fix(api): compute audit progress correctly

### DIFF
--- a/confiture-rest-api/src/audits/audit.service.ts
+++ b/confiture-rest-api/src/audits/audit.service.ts
@@ -1324,9 +1324,13 @@ export class AuditService {
       ];
 
       const pagesResults = a.pages.flatMap((p) => p.results);
-
+      const actualResults = pagesResults.filter((r) =>
+        CRITERIA_BY_AUDIT_TYPE[a.auditType].find(
+          (e) => e.topic === r.topic && e.criterium === r.criterium
+        )
+      );
       const progress =
-        pagesResults.filter(
+        actualResults.filter(
           (r) => r.status !== CriterionResultStatus.NOT_TESTED
         ).length /
         (CRITERIA_BY_AUDIT_TYPE[a.auditType].length * a.pages.length);
@@ -1377,9 +1381,9 @@ export class AuditService {
       const statementIsPublished = !!a.initiator;
 
       const auditIsComplete =
-        pagesResults.length ===
+        actualResults.length ===
           CRITERIA_BY_AUDIT_TYPE[a.auditType].length * a.pages.length &&
-        pagesResults.every((r) => r.status !== "NOT_TESTED");
+        actualResults.every((r) => r.status !== "NOT_TESTED");
 
       return {
         ...pick(


### PR DESCRIPTION
In getAuditsByAuditorEmail, filter criteria out of audit type criteria list when computing progress.
Bug used to occur for example when changing from 106 criteria to 50 or 25.

closes #1071

Avant de merger la pull request, s’assurer que :

- Les checks GitHub passent (lint...).
- Les tests Cypress ont été lancés en local (dans le cas d’une correction de bug ou d’une nouvelle fonctionnalité).
