### PR TITLE
directly import hljs themes files content in project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 <h2 class="fr-sr-only" id="2025">2025</h2>
 
+### 22/05/2025
+
+#### <span aria-hidden="true">🐛</span> Corrections
+
+- Corrige l’affichage des blocs de code dans l’éditeur quand le thème (clair ou sombre) du site est différent du thème système ([#1117](https://github.com/DISIC/Ara/pull/1117))
+
 ### 21/05/2025
 
 #### <span aria-hidden="true">🐛</span> Corrections

--- a/confiture-web-app/src/components/tiptap/TiptapEditor.vue
+++ b/confiture-web-app/src/components/tiptap/TiptapEditor.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { type Level } from "@tiptap/extension-heading";
 import { Editor, EditorContent, useEditor } from "@tiptap/vue-3";
-import { onBeforeUnmount, onMounted, ShallowRef, watch } from "vue";
+import { onBeforeUnmount, ShallowRef, watch } from "vue";
 
 import { useUniqueId } from "../../composables/useUniqueId";
 import { displayedHeadings, tiptapExtensions } from "./tiptap-extensions";

--- a/confiture-web-app/src/components/tiptap/TiptapEditor.vue
+++ b/confiture-web-app/src/components/tiptap/TiptapEditor.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import { type Level } from "@tiptap/extension-heading";
 import { Editor, EditorContent, useEditor } from "@tiptap/vue-3";
-import { onBeforeUnmount, ShallowRef, watch } from "vue";
+import { onBeforeUnmount, onMounted, ShallowRef, watch } from "vue";
 
 import { useUniqueId } from "../../composables/useUniqueId";
 import { displayedHeadings, tiptapExtensions } from "./tiptap-extensions";
@@ -276,6 +276,7 @@ defineExpose({
 
 <style>
 @import url("./tiptap.css");
+@import url("./tiptap-hljs.css");
 
 /* Container */
 .tiptap-container {
@@ -285,11 +286,11 @@ defineExpose({
   border: 1px solid var(--border-plain-grey);
   border-bottom: 0;
   box-shadow: inset 0 -2px 0 0 var(--border-plain-grey);
+}
 
-  /* Override bg color in dark mode to avoid same color as wrapper */
-  @media (prefers-color-scheme: dark) {
-    background-color: var(--background-contrast-grey);
-  }
+/* Override bg color in dark mode to avoid same color as wrapper */
+[data-fr-theme="dark"] .tiptap-container {
+  background-color: var(--background-contrast-grey);
 }
 
 .tiptap-container--not-editable {

--- a/confiture-web-app/src/components/tiptap/TiptapRenderer.vue
+++ b/confiture-web-app/src/components/tiptap/TiptapRenderer.vue
@@ -43,4 +43,5 @@ onMounted(() => {
 
 <style>
 @import url("./tiptap.css");
+@import url("./tiptap-hljs.css");
 </style>

--- a/confiture-web-app/src/components/tiptap/tiptap-hljs.css
+++ b/confiture-web-app/src/components/tiptap/tiptap-hljs.css
@@ -1,0 +1,255 @@
+[data-fr-theme="dark"] {
+  /*!
+  Theme: GitHub Dark
+  Description: Dark theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-dark
+  Current colors taken from GitHub's CSS
+*/
+
+  .hljs {
+    color: #c9d1d9;
+    background: #0d1117;
+  }
+
+  .hljs-doctag,
+  .hljs-keyword,
+  .hljs-meta .hljs-keyword,
+  .hljs-template-tag,
+  .hljs-template-variable,
+  .hljs-type,
+  .hljs-variable.language_ {
+    /* prettylights-syntax-keyword */
+    color: #ff7b72;
+  }
+
+  .hljs-title,
+  .hljs-title.class_,
+  .hljs-title.class_.inherited__,
+  .hljs-title.function_ {
+    /* prettylights-syntax-entity */
+    color: #d2a8ff;
+  }
+
+  .hljs-attr,
+  .hljs-attribute,
+  .hljs-literal,
+  .hljs-meta,
+  .hljs-number,
+  .hljs-operator,
+  .hljs-variable,
+  .hljs-selector-attr,
+  .hljs-selector-class,
+  .hljs-selector-id {
+    /* prettylights-syntax-constant */
+    color: #79c0ff;
+  }
+
+  .hljs-regexp,
+  .hljs-string,
+  .hljs-meta .hljs-string {
+    /* prettylights-syntax-string */
+    color: #a5d6ff;
+  }
+
+  .hljs-built_in,
+  .hljs-symbol {
+    /* prettylights-syntax-variable */
+    color: #ffa657;
+  }
+
+  .hljs-comment,
+  .hljs-code,
+  .hljs-formula {
+    /* prettylights-syntax-comment */
+    color: #8b949e;
+  }
+
+  .hljs-name,
+  .hljs-quote,
+  .hljs-selector-tag,
+  .hljs-selector-pseudo {
+    /* prettylights-syntax-entity-tag */
+    color: #7ee787;
+  }
+
+  .hljs-subst {
+    /* prettylights-syntax-storage-modifier-import */
+    color: #c9d1d9;
+  }
+
+  .hljs-section {
+    /* prettylights-syntax-markup-heading */
+    color: #1f6feb;
+    font-weight: bold;
+  }
+
+  .hljs-bullet {
+    /* prettylights-syntax-markup-list */
+    color: #f2cc60;
+  }
+
+  .hljs-emphasis {
+    /* prettylights-syntax-markup-italic */
+    color: #c9d1d9;
+    font-style: italic;
+  }
+
+  .hljs-strong {
+    /* prettylights-syntax-markup-bold */
+    color: #c9d1d9;
+    font-weight: bold;
+  }
+
+  .hljs-addition {
+    /* prettylights-syntax-markup-inserted */
+    color: #aff5b4;
+    background-color: #033a16;
+  }
+
+  .hljs-deletion {
+    /* prettylights-syntax-markup-deleted */
+    color: #ffdcd7;
+    background-color: #67060c;
+  }
+
+  .hljs-char.escape_,
+  .hljs-link,
+  .hljs-params,
+  .hljs-property,
+  .hljs-punctuation,
+  .hljs-tag {
+    /* purposely ignored */
+  }
+}
+
+[data-fr-theme="light"] {
+  /*!
+  Theme: GitHub
+  Description: Light theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-light
+  Current colors taken from GitHub's CSS
+*/
+
+  .hljs {
+    color: #24292e;
+    background: #ffffff;
+  }
+
+  .hljs-doctag,
+  .hljs-keyword,
+  .hljs-meta .hljs-keyword,
+  .hljs-template-tag,
+  .hljs-template-variable,
+  .hljs-type,
+  .hljs-variable.language_ {
+    /* prettylights-syntax-keyword */
+    color: #d73a49;
+  }
+
+  .hljs-title,
+  .hljs-title.class_,
+  .hljs-title.class_.inherited__,
+  .hljs-title.function_ {
+    /* prettylights-syntax-entity */
+    color: #6f42c1;
+  }
+
+  .hljs-attr,
+  .hljs-attribute,
+  .hljs-literal,
+  .hljs-meta,
+  .hljs-number,
+  .hljs-operator,
+  .hljs-variable,
+  .hljs-selector-attr,
+  .hljs-selector-class,
+  .hljs-selector-id {
+    /* prettylights-syntax-constant */
+    color: #005cc5;
+  }
+
+  .hljs-regexp,
+  .hljs-string,
+  .hljs-meta .hljs-string {
+    /* prettylights-syntax-string */
+    color: #032f62;
+  }
+
+  .hljs-built_in,
+  .hljs-symbol {
+    /* prettylights-syntax-variable */
+    color: #e36209;
+  }
+
+  .hljs-comment,
+  .hljs-code,
+  .hljs-formula {
+    /* prettylights-syntax-comment */
+    color: #6a737d;
+  }
+
+  .hljs-name,
+  .hljs-quote,
+  .hljs-selector-tag,
+  .hljs-selector-pseudo {
+    /* prettylights-syntax-entity-tag */
+    color: #22863a;
+  }
+
+  .hljs-subst {
+    /* prettylights-syntax-storage-modifier-import */
+    color: #24292e;
+  }
+
+  .hljs-section {
+    /* prettylights-syntax-markup-heading */
+    color: #005cc5;
+    font-weight: bold;
+  }
+
+  .hljs-bullet {
+    /* prettylights-syntax-markup-list */
+    color: #735c0f;
+  }
+
+  .hljs-emphasis {
+    /* prettylights-syntax-markup-italic */
+    color: #24292e;
+    font-style: italic;
+  }
+
+  .hljs-strong {
+    /* prettylights-syntax-markup-bold */
+    color: #24292e;
+    font-weight: bold;
+  }
+
+  .hljs-addition {
+    /* prettylights-syntax-markup-inserted */
+    color: #22863a;
+    background-color: #f0fff4;
+  }
+
+  .hljs-deletion {
+    /* prettylights-syntax-markup-deleted */
+    color: #b31d28;
+    background-color: #ffeef0;
+  }
+
+  .hljs-char.escape_,
+  .hljs-link,
+  .hljs-params,
+  .hljs-property,
+  .hljs-punctuation,
+  .hljs-tag {
+    /* purposely ignored */
+  }
+}

--- a/confiture-web-app/src/components/tiptap/tiptap.css
+++ b/confiture-web-app/src/components/tiptap/tiptap.css
@@ -1,8 +1,3 @@
-@import url("highlight.js/styles/github.css") screen and
-  (prefers-color-scheme: light);
-@import url("highlight.js/styles/github-dark.css") screen and
-  (prefers-color-scheme: dark);
-
 .tiptap {
   min-height: 10rem;
   padding: 0.5rem 0.75rem;


### PR DESCRIPTION
closes #1116 

Pas la solution la plus élégante mais ça fonctionne, c'est basé sur l'attribut `data-fr-theme` du `<html>` (au lieu de la MQ `prefers-colors-scheme`) et a priori le contenu du fichier du thème ne changera jamais.