### PR TITLE
N'affiche pas le temps relative dans l'indicateur d'enregistrement s'il n'y en a pas

### DIFF
--- a/confiture-web-app/src/components/audit/SaveIndicator.vue
+++ b/confiture-web-app/src/components/audit/SaveIndicator.vue
@@ -141,7 +141,10 @@ watch(
       aria-hidden="true"
     >
       {{ saveContent.description }}
-      <small class="fr-text--xs fr-m-0 save-indicator-relative-time">
+      <small
+        v-if="relativeLastSaveDate"
+        class="fr-text--xs fr-m-0 save-indicator-relative-time"
+      >
         Dernier enregistrement {{ relativeLastSaveDate }}.
       </small>
     </span>


### PR DESCRIPTION
closes #1136 