### PR TITLE
Le focus peut sortir de la modale observations

### DIFF
--- a/confiture-web-app/src/components/ui/FileUpload.vue
+++ b/confiture-web-app/src/components/ui/FileUpload.vue
@@ -24,7 +24,7 @@ const props = withDefaults(defineProps<Props>(), {
   boldTitle: false,
   errorMessage: null,
   errorMessageTitle: null,
-  maxFileSize: "2 Mo",
+  maxFileSize: "2 Mo",
   multiple: false,
   readonly: false,
   title: null

--- a/confiture-web-app/src/components/ui/FileUpload.vue
+++ b/confiture-web-app/src/components/ui/FileUpload.vue
@@ -38,7 +38,7 @@ const emit = defineEmits<{
 defineExpose({ onFileRequestFinished });
 
 const localErrorMessage: Ref<FileErrorMessage | null> = ref(null);
-const isDraggedOver: Ref<boolean> = ref(false);
+const isDraggedOver = ref(false);
 
 const id = useUniqueId();
 const isOffline = useIsOffline();
@@ -71,15 +71,8 @@ const acceptedFormatsAttr = computed(() => {
   }
 });
 
-const computedErrorMessage = computed(() => {
-  if (props.errorMessage) {
-    return props.errorMessage;
-  } else if (localErrorMessage.value) {
-    return localErrorMessage.value;
-  } else {
-    return null;
-  }
-});
+const computedErrorMessage = computed(() =>
+  props.errorMessage ?? localErrorMessage.value ?? null);
 
 const title = computed(() => {
   if (props.title) {
@@ -175,6 +168,7 @@ function onFileRequestFinished() {
         >
         <div :id="`file-upload-messages-${id}`" class="fr-messages-group" aria-live="assertive" aria-atomic="true">
           <p
+            v-if="computedErrorMessage"
             class="fr-message"
             :class="{ 'fr-message--error': computedErrorMessage }"
           >{{ computedErrorMessage }}</p>
@@ -289,6 +283,7 @@ function onFileRequestFinished() {
   max-width: 100%;
   object-fit: contain;
 }
+
 .file-thumbnail__default {
   display: flex;
   justify-content: center;
@@ -300,10 +295,12 @@ function onFileRequestFinished() {
 .file-thumbnail__default::before {
   --icon-size: 2.5rem;
 }
+
 .fr-upload-group .fr-label + .fr-upload {
-  margin-top: 0.5rem;
+  margin-block-start: 0.5rem;
   padding-block: 0.5rem;
 }
+
 .file-upload--dragged-over {
   outline-style: dotted;
   outline-width: 3px;

--- a/confiture-web-app/src/enums.ts
+++ b/confiture-web-app/src/enums.ts
@@ -28,7 +28,7 @@ export enum Browsers {
 
 /* UPLOAD_FORMAT should never happen… */
 export enum FileErrorMessage {
-  UPLOAD_SIZE = "Votre fichier dépasse la limite de 2 Mo. Veuillez choisir un fichier plus léger.",
+  UPLOAD_SIZE = "Votre fichier dépasse la limite de 2 Mo. Veuillez choisir un fichier plus léger.",
   UPLOAD_FORMAT = "Format de fichier non supporté.",
   UPLOAD_FORMAT_EXAMPLE = "Format de fichier non supporté. Veuillez choisir un fichier jpg, jpeg ou png.",
   UPLOAD_UNKNOWN = "Une erreur inconnue empêche le téléchargement du fichier. Veuillez réessayer.",

--- a/confiture-web-app/src/utils.ts
+++ b/confiture-web-app/src/utils.ts
@@ -121,7 +121,7 @@ export function slugify(value: string): string {
 }
 
 export function formatBytes(bytes: number, decimals = 0) {
-  if (!+bytes) return "0 octets";
+  if (!+bytes) return "0 octet";
 
   const k = 1024;
   const dm = decimals < 0 ? 0 : decimals;
@@ -129,7 +129,7 @@ export function formatBytes(bytes: number, decimals = 0) {
 
   const i = Math.floor(Math.log(bytes) / Math.log(k));
 
-  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
 }
 
 /**


### PR DESCRIPTION
On change le composant d’upload de fichier pour une version utilisant le bouton natif.
Plus accessible, et corrige le problème du focus qui sort de la modale.

closes #1162

Avant de merger la pull request, s’assurer que :

- Les checks GitHub passent (lint...).
- Les tests Cypress ont été lancés en local (dans le cas d’une correction de bug ou d’une nouvelle fonctionnalité).
