### PR TITLE
fix(audits): rendre auditorEmail obligatoire pour renvoyer un 400 au lieu d'un 500

### DIFF
--- a/confiture-rest-api/src/audits/dto/requests/create-audit.dto.ts
+++ b/confiture-rest-api/src/audits/dto/requests/create-audit.dto.ts
@@ -62,7 +62,6 @@ export class BaseAuditDto {
    * @example "john@audit.com"
    */
   @IsEmail()
-  @IsOptional()
   auditorEmail: string;
 }
 


### PR DESCRIPTION
## Problème
`POST /api/audits` renvoie un **500 Internal Server Error** lorsque `auditorEmail` est absent du corps de la requête, au lieu d'un **400 Bad Request** listant le champ manquant.

## Cause
Dans `BaseAuditDto`, `auditorEmail` était marqué `@IsOptional()`. La validation passait donc quand le champ était absent, mais le service l'utilise ensuite sans condition (`data.auditorEmail.toLowerCase()`), ce qui provoque le crash 500.

## Correctif
Retrait de `@IsOptional()` sur `auditorEmail`. La validation renvoie désormais un **400** propre listant `auditorEmail` quand il est absent.

Ce changement est cohérent avec le type du champ (`auditorEmail: string`, non optionnel), les autres champs `@IsEmail()` du projet (tous obligatoires) et l'usage sans condition de `auditorEmail` dans `AuditService` (création **et** mise à jour).

Closes #1583