### PR TITLE
prune les dépendances manuellement pour réduire la taille de l’image sur scalingo

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: node confiture-rest-api/dist/main.js
-postdeploy: yarn workspace confiture-rest-api run prisma migrate deploy
+postdeploy: yarn workspace confiture-rest-api run prisma migrate deploy && yarn workspace confiture-rest-api run db:seed

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: node confiture-rest-api/dist/main.js
-postdeploy: yarn workspace confiture-rest-api run prisma migrate deploy && yarn workspace confiture-rest-api run db:seed
+postdeploy: yarn workspace confiture-rest-api run prisma migrate deploy

--- a/scalingo.json
+++ b/scalingo.json
@@ -2,9 +2,6 @@
   "env": {
     "FRONT_BASE_URL": {
       "generator": "url"
-    },
-    "YARN2_SKIP_PRUNING": {
-      "value": "true"
     }
   }
 }

--- a/scalingo.json
+++ b/scalingo.json
@@ -2,6 +2,9 @@
   "env": {
     "FRONT_BASE_URL": {
       "generator": "url"
+    },
+    "YARN2_SKIP_PRUNING": {
+      "value": "true"
     }
   }
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,11 +3,20 @@ set -e
 
 echo "🚧 BUILDING... Generating API types..."
 yarn copytypes
+
 echo "🚧 BUILDING... Generating RGAA files..."
 yarn workspace confiture-web-app run generate:rgaa
-echo "🚧 BUILDING... Building apps..."
-yarn workspaces foreach --all run build
+
+echo "🚧 BUILDING... Building client app..."
+yarn workspace confiture-web-app run build
+echo "🚧 BUILDING... Building backend app..."
+yarn workspace confiture-rest-api run build
+
 echo "🚧 BUILDING... Moving frontend build to backend static folder"
 rm -rf confiture-rest-api/client
 mv confiture-web-app/dist confiture-rest-api/client
+
+echo "🚧 BUILDING... Pruning dependencies"
+yarn workspaces focus --production --all
+
 echo "✅ BUILDING DONE !"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -18,5 +18,6 @@ mv confiture-web-app/dist confiture-rest-api/client
 
 echo "🚧 BUILDING... Pruning dependencies"
 yarn workspaces focus --production --all
+yarn cache clean
 
 echo "✅ BUILDING DONE !"


### PR DESCRIPTION
Pour une raison que j’ignore, le pruning de scalingo n’a aucun effet sur notre projet (image de 1.9Go avec ou sans le pruning de scalingo)

En lançant 
```sh
yarn workspaces focus --production --all
yarn cache clean
```
dans le script de build, on arrive à une taille finale de `1.2Go`